### PR TITLE
Save grid settings for GUI

### DIFF
--- a/src/main/java/net/mcreator/element/types/GUI.java
+++ b/src/main/java/net/mcreator/element/types/GUI.java
@@ -50,6 +50,13 @@ import java.util.List;
 	public Procedure onTick;
 	public Procedure onClosed;
 
+	//Used by MCToolkit only
+	public int sx = 18;
+	public int sy = 18;
+	public int ox = 11;
+	public int oy = 15;
+	public boolean snapOnGrid;
+
 	public final transient int W;
 	public final transient int H;
 

--- a/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
@@ -106,6 +106,16 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 			editor.slot2.setEnabled(true);
 		}
 
+		editor.sx.setValue(gui.sx);
+		editor.sy.setValue(gui.sy);
+		editor.ox.setValue(gui.ox);
+		editor.oy.setValue(gui.oy);
+		editor.snapOnGrid.setSelected(gui.snapOnGrid);
+		if(gui.snapOnGrid){
+			editor.editor.showGrid = true;
+			editor.editor.repaint();
+		}
+
 		editor.setOpening(false);
 	}
 
@@ -122,6 +132,12 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 		gui.onOpen = onOpen.getSelectedProcedure();
 		gui.onTick = onTick.getSelectedProcedure();
 		gui.onClosed = onClosed.getSelectedProcedure();
+
+		gui.sx = (int) editor.sx.getValue();
+		gui.sy = (int) editor.sy.getValue();
+		gui.ox = (int) editor.ox.getValue();
+		gui.oy = (int) editor.oy.getValue();
+		gui.snapOnGrid = editor.snapOnGrid.isSelected();
 		return gui;
 	}
 

--- a/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYG.java
+++ b/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYG.java
@@ -58,7 +58,7 @@ public class WYSIWYG extends JComponent implements MouseMotionListener, MouseLis
 	private boolean componentMoveMode;
 	private boolean componentDragMode;
 
-	boolean showGrid = false;
+	public boolean showGrid = false;
 
 	@Nullable private GUIComponent selected;
 

--- a/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYGEditor.java
+++ b/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYGEditor.java
@@ -66,6 +66,13 @@ public class WYSIWYGEditor extends JPanel {
 	public JSpinner invOffX = new JSpinner(new SpinnerNumberModel(0, -256, 256, 1));
 	public JSpinner invOffY = new JSpinner(new SpinnerNumberModel(0, -256, 256, 1));
 
+	public JSpinner sx = new JSpinner(new SpinnerNumberModel(18, 1, 100, 1));
+	public JSpinner sy = new JSpinner(new SpinnerNumberModel(18, 1, 100, 1));
+	public JSpinner ox = new JSpinner(new SpinnerNumberModel(11, 1, 100, 1));
+	public JSpinner oy = new JSpinner(new SpinnerNumberModel(15, 1, 100, 1));
+
+	public JCheckBox snapOnGrid = new JCheckBox((L10N.t("elementgui.gui.snap_components_on_grid")));
+
 	public JButton button = new JButton(UIRES.get("32px.addbutton"));
 	public JButton text = new JButton(UIRES.get("32px.addtextinput"));
 	public JButton slot1 = new JButton(UIRES.get("32px.addinslot"));
@@ -252,17 +259,11 @@ public class WYSIWYGEditor extends JPanel {
 		slot1.addActionListener(e -> new InputSlotDialog(this, null));
 		slot2.addActionListener(e -> new OutputSlotDialog(this, null));
 
-		JCheckBox snapOnGrid = new JCheckBox((L10N.t("elementgui.gui.snap_components_on_grid")));
 		snapOnGrid.setOpaque(false);
 		snapOnGrid.addActionListener(event -> {
 			editor.showGrid = snapOnGrid.isSelected();
 			editor.repaint();
 		});
-
-		JSpinner sx = new JSpinner(new SpinnerNumberModel(18, 1, 100, 1));
-		JSpinner sy = new JSpinner(new SpinnerNumberModel(18, 1, 100, 1));
-		JSpinner ox = new JSpinner(new SpinnerNumberModel(11, 1, 100, 1));
-		JSpinner oy = new JSpinner(new SpinnerNumberModel(15, 1, 100, 1));
 
 		sx.addChangeListener(e -> {
 			editor.grid_x_spacing = (int) sx.getValue();


### PR DESCRIPTION
This PR adds an auto save for the grid settings. When a GUI mod element is saved, grid settings are saved in the same JSOn file than the mod element, so when we re-open this GUI, grid settings are changed for the saved settings.
Closes #87 