### PR TITLE
Reload plugins button

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -12,6 +12,7 @@ action.mcreator_website=MCreator''s website
 action.mcreator_community=MCreator''s community
 action.publish_modification=Publish my modification...
 action.preferences=Preferences...
+action.reload_plugins=Reload plugins...
 action.exit=Exit MCreator
 action.wiki=Online help
 action.support=Support
@@ -986,6 +987,9 @@ preferences.ui.autoreloadTabs=Automatically reload data inside tabs
 preferences.ui.autoreloadTabs.description=Disable this option if you are having performance problems when switching tabs
 preferences.ui.discordRichPresenceEnable=Enable Discord Rich Presence
 preferences.ui.discordRichPresenceEnable.description=When this is enabled, Discord app will show that you are using MCreator
+preferences.ui.developerFeatures=Enable developer features
+preferences.ui.developerFeatures.description=This parameter enables features for developers.\
+  <br> WARNING: This parameter should not be used by regular users.
 preferences.backups.workspaceAutosaveInterval=Workspace autosave interval (in seconds)
 preferences.backups.workspaceAutosaveInterval.description=This parameter defines how often the workspace should be auto-saved in case there were any changes.<br>\
   Workspace is also autosaved when MCreator is closed.
@@ -1162,6 +1166,17 @@ dialog.about.third_party.message=<html>Third-Party licenses are located in the <
 dialog.about.third_party.title=Third-Party licenses
 dialog.about.eula.title=MCreator License
 dialog.about.eula.close=Close
+dialog.reload_plugins.option.message=<html><b>Are you sure you want to reload plugins?</b><br>\
+  This action can break your workspace. You should not use it if you are a regular user.<br>\
+  If you use it and you have a problem with your workspace, do not come to ask for support. We won't help you.
+dialog.reload_plugins.title=Reload plugins
+dialog.reload_plugins.progress.loading_plugins=Reloading plugins...
+dialog.reload_plugins.progress.loading_l10n_and_helps=Reloading L10N and in-app helps...
+dialog.reload_plugins.progress.loading_datalists_and_icons=Reloading data lists and icons...
+dialog.reload_plugins.progress.loading_apis=Reloading APIs...
+dialog.reload_plugins.progress.loading_blockly=Reloading Blockly...
+dialog.reload_plugins.progress.loading_others=Reloading other data...
+dialog.reload_plugins.option.reload=Confirm and reload
 action.keyboard_shortcuts=Keyboard shortcuts
 action.knowledge_base=Knowledge base
 action.donate=Donate

--- a/src/main/java/net/mcreator/preferences/PreferencesData.java
+++ b/src/main/java/net/mcreator/preferences/PreferencesData.java
@@ -54,6 +54,7 @@ public class PreferencesData {
 		@PreferencesEntry public boolean use2DAcceleration = false;
 		@PreferencesEntry public boolean autoreloadTabs = true;
 		@PreferencesEntry public boolean discordRichPresenceEnable = true;
+		@PreferencesEntry public boolean developerFeatures = false;
 
 	}
 

--- a/src/main/java/net/mcreator/ui/MainMenuBar.java
+++ b/src/main/java/net/mcreator/ui/MainMenuBar.java
@@ -18,6 +18,7 @@
 
 package net.mcreator.ui;
 
+import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.action.BasicAction;
 import net.mcreator.ui.component.SocialButtons;
 import net.mcreator.ui.component.util.ComponentUtils;
@@ -102,6 +103,8 @@ public class MainMenuBar extends JMenuBar {
 		file.add(mcreator.actionRegistry.closeWorkspace);
 		file.addSeparator();
 		file.add(mcreator.actionRegistry.preferences);
+		if(PreferencesManager.PREFERENCES.ui.developerFeatures)
+			file.add(mcreator.actionRegistry.reloadPlugins);
 		file.addSeparator();
 		file.add(mcreator.actionRegistry.exitMCreator);
 		add(file);

--- a/src/main/java/net/mcreator/ui/action/ActionRegistry.java
+++ b/src/main/java/net/mcreator/ui/action/ActionRegistry.java
@@ -20,10 +20,7 @@ package net.mcreator.ui.action;
 
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.MCreatorApplication;
-import net.mcreator.ui.action.impl.AboutAction;
-import net.mcreator.ui.action.impl.CheckForUpdatesAction;
-import net.mcreator.ui.action.impl.MinecraftFolderActions;
-import net.mcreator.ui.action.impl.ShowDataListAction;
+import net.mcreator.ui.action.impl.*;
 import net.mcreator.ui.action.impl.gradle.*;
 import net.mcreator.ui.action.impl.vcs.*;
 import net.mcreator.ui.action.impl.workspace.*;
@@ -70,6 +67,7 @@ public class ActionRegistry {
 	public final BasicAction preferences;
 	public final BasicAction closeWorkspace;
 	public final BasicAction exitMCreator;
+	public final BasicAction reloadPlugins;
 
 	// File menu
 	public final BasicAction openWorkspace;
@@ -204,6 +202,7 @@ public class ActionRegistry {
 				MCreatorApplication.SERVER_DOMAIN + "/node/add/modification/");
 		this.preferences = new BasicAction(this, L10N.t("action.preferences"),
 				e -> new PreferencesDialog(mcreator, null)).setIcon(UIRES.get("settings"));
+		this.reloadPlugins = new ReloadPlugins(this);
 		this.exitMCreator = new BasicAction(this, L10N.t("action.exit"),
 				e -> mcreator.getApplication().closeApplication());
 		this.aboutMCreator = new AboutAction(this);

--- a/src/main/java/net/mcreator/ui/action/impl/ReloadPlugins.java
+++ b/src/main/java/net/mcreator/ui/action/impl/ReloadPlugins.java
@@ -1,0 +1,121 @@
+/*
+ * MCToolkit (https://mctoolkit.net/)
+ * Copyright (C) 2020 MCToolkit and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.action.impl;
+
+import net.mcreator.blockly.data.BlocklyLoader;
+import net.mcreator.gradle.GradleDaemonUtils;
+import net.mcreator.io.FileIO;
+import net.mcreator.io.UserFolderManager;
+import net.mcreator.minecraft.DataListLoader;
+import net.mcreator.minecraft.api.ModAPIManager;
+import net.mcreator.plugin.PluginLoader;
+import net.mcreator.ui.MCreator;
+import net.mcreator.ui.action.ActionRegistry;
+import net.mcreator.ui.action.BasicAction;
+import net.mcreator.ui.dialogs.ProgressDialog;
+import net.mcreator.ui.dialogs.tools.plugin.PackMakerToolIcons;
+import net.mcreator.ui.dialogs.tools.plugin.PackMakerToolLoader;
+import net.mcreator.ui.help.HelpLoader;
+import net.mcreator.ui.init.BlockItemIcons;
+import net.mcreator.ui.init.ImageMakerTexturesCache;
+import net.mcreator.ui.init.L10N;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+public class ReloadPlugins extends BasicAction {
+	public ReloadPlugins(ActionRegistry actionRegistry) {
+		super(actionRegistry, L10N.t("action.reload_plugins"), e -> {
+			Object[] options = { L10N.t("dialog.reload_plugins.option.reload"),
+					UIManager.getString("OptionPane.cancelButtonText") };
+			int reply = JOptionPane
+					.showOptionDialog(actionRegistry.getMCreator(), L10N.t("dialog.reload_plugins.option.message"),
+							L10N.t("dialog.reload_plugins.title"), JOptionPane.YES_NO_OPTION,
+							JOptionPane.WARNING_MESSAGE, null, options, options[0]);
+			if (reply == 0 || reply == 1) {
+				reloadPlugins(actionRegistry.getMCreator());
+			}
+
+		});
+	}
+
+	private static void reloadPlugins(MCreator mcreator){
+		ProgressDialog progressDialog = new ProgressDialog(mcreator, L10N.t("dialog.reload_plugins.title"));
+		new Thread(() -> {
+			ProgressDialog.ProgressUnit p1 = new ProgressDialog.ProgressUnit(
+					L10N.t("dialog.reload_plugins.progress.loading_plugins"));
+			progressDialog.addProgress(p1);
+
+			PluginLoader.initInstance();
+			progressDialog.refreshDisplay();
+			p1.ok();
+
+			ProgressDialog.ProgressUnit p2 = new ProgressDialog.ProgressUnit(
+					L10N.t("dialog.reload_plugins.progress.loading_l10n_and_helps"));
+			progressDialog.addProgress(p2);
+			// load translations after plugins are loaded
+			L10N.initTranslations();
+			// preload help entries cache
+			HelpLoader.preloadCache();
+
+			p2.ok();
+			progressDialog.refreshDisplay();
+
+			ProgressDialog.ProgressUnit p3 = new ProgressDialog.ProgressUnit(
+					L10N.t("dialog.reload_plugins.progress.loading_datalists_and_icons"));
+			progressDialog.addProgress(p3);
+			// load datalists and icons for them after plugins are loaded
+			BlockItemIcons.init();
+			DataListLoader.preloadCache();
+			p3.ok();
+
+			ProgressDialog.ProgressUnit p4 = new ProgressDialog.ProgressUnit(
+					L10N.t("dialog.reload_plugins.progress.loading_apis"));
+			progressDialog.addProgress(p4);
+			// load apis defined by plugins after plugins are loaded
+			ModAPIManager.initAPIs();
+			p4.ok();
+
+			ProgressDialog.ProgressUnit p5 = new ProgressDialog.ProgressUnit(
+					L10N.t("dialog.reload_plugins.progress.loading_blockly"));
+			progressDialog.addProgress(p5);
+			// load blockly blocks after plugins are loaded
+			BlocklyLoader.init();
+			p5.ok();
+
+			ProgressDialog.ProgressUnit p6 = new ProgressDialog.ProgressUnit(
+					L10N.t("dialog.reload_plugins.progress.loading_others"));
+			progressDialog.addProgress(p6);
+			// load templates for image maker
+			ImageMakerTexturesCache.init();
+			// load pack makers defined by plugins after plugins are loaded
+			PackMakerToolIcons.init();
+			PackMakerToolLoader.init();
+			p6.ok();
+
+			progressDialog.refreshDisplay();
+
+			progressDialog.hideAll();
+		}).start();
+		progressDialog.setVisible(true);
+	}
+}


### PR DESCRIPTION
This PR adds a new button (in the "File" section) to reload plugins. As it should not be used by regular users (otherwise, why Klemen didn't add this feature sooner), I added a dialog box to confirm saying it should not be used. I also added a new preference entry to enable developer features and when this preference is not enabled, the button won't be added.

Note: If localizations are changed, the current tab has to be re-opened to use the new translations.

I know this feature can seem to be useless, but I'm bored to always have to re-run MCreator every time I have to change one small thing in a file of plugin. It will save a lot of time for the development.